### PR TITLE
Fix issue with mixing pip and system packages for wheel and virtualenv

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1
 commit = False
 tag = False
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     cfssl:
       runs-on: ubuntu-latest
       steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: docker build --target api -t rasenmaeher_cfssl .
       - run: docker run -d -p 8888:8888 --name rasenmaeher_cfssl rasenmaeher_cfssl
       - run: sleep 60 && docker logs rasenmaeher_cfssl
@@ -22,7 +22,7 @@ jobs:
         matrix:
           python-version: ["3.11"] # , "3.12"]
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - name: Set up Python ${{ matrix.python-version }}
           uses: actions/setup-python@v4
           with:
@@ -49,7 +49,7 @@ jobs:
     restwrapper_docker:
       runs-on: ubuntu-latest
       steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: docker build --target ocsprest -t rasenmaeher_ocsprest .
       - run: docker run -d -p 8887:8887 --name rasenmaeher_ocsprest rasenmaeher_ocsprest
       - run: sleep 3 && docker logs rasenmaeher_ocsprest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,3 +45,13 @@ jobs:
             report_paths: '**/pytest*.xml'
             detailed_summary: true
             check_name: 'JUnit report (local)'
+
+    restwrapper_docker:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v3
+      - run: docker build --target ocsprest -t rasenmaeher_ocsprest .
+      - run: docker run -d -p 8887:8887 --name rasenmaeher_ocsprest rasenmaeher_ocsprest
+      - run: sleep 3 && docker logs rasenmaeher_ocsprest
+      - run: echo 'print whole trace' && curl http://localhost:8887/api/v1/healthcheck
+      - run: echo 'verify success' && curl http://localhost:8887/api/v1/healthcheck | grep 'success'

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ RUN apt-get update \
       python3-pip \
       curl \
       jq \
+      python3-virtualenv \
+      python3-wheel \
     # Installing `poetry` package manager:
     && curl -sSL https://install.python-poetry.org | python3 - \
     && echo 'export PATH="/root/.local/bin:$PATH"' >>/root/.profile \
@@ -64,8 +66,7 @@ RUN apt-get update \
 WORKDIR /pysetup
 COPY ./poetry.lock ./pyproject.toml /pysetup/
 # Install basic requirements (utilizing an internal docker wheelhouse if available)
-RUN pip3 install wheel virtualenv \
-    && poetry export -f requirements.txt --without-hashes -o /tmp/requirements.txt \
+RUN poetry export -f requirements.txt --without-hashes -o /tmp/requirements.txt \
     && pip3 wheel --wheel-dir=/tmp/wheelhouse  -r /tmp/requirements.txt \
     && virtualenv /.venv && source /.venv/bin/activate && echo 'source /.venv/bin/activate' >>/root/.profile \
     && pip3 install --no-deps --find-links=/tmp/wheelhouse/ /tmp/wheelhouse/*.whl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN apt-get update && apt-get install -y \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
     && WHEELFILE=`echo /tmp/wheelhouse/ocsprest-*.whl` \
-    && pip3 install --find-links=/tmp/wheelhouse/ "$WHEELFILE"[all] \
+    && pip3 install --break-system-packages --find-links=/tmp/wheelhouse/ "$WHEELFILE"[all] \
     && rm -rf /tmp/wheelhouse/ \
     # Do whatever else you need to
     && true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ocsprest"
-version = "1.0.0"
+version = "1.0.1"
 description = ""
 authors = ["Eero af Heurlin <eero.afheurlin@iki.fi>"]
 readme = "README.rst"

--- a/src/ocsprest/__init__.py
+++ b/src/ocsprest/__init__.py
@@ -1,2 +1,2 @@
 """Quick and dirty rest API to call the ocsp signing methods for CFSSL CLI"""
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/tests/test_ocsprest.py
+++ b/tests/test_ocsprest.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.0.0"
+    assert __version__ == "1.0.1"
 
 
 def test_healthcheck(client: TestClient) -> None:


### PR DESCRIPTION
The issue

```console
#34 0.550 error: externally-managed-environment
#34 0.550 
#34 0.550 × This environment is externally managed
#34 0.550 ╰─> To install Python packages system-wide, try apt install
#34 0.550     python3-xyz, where xyz is the package you are trying to
#34 0.550     install.
#34 0.550     
#34 0.550     If you wish to install a non-Debian-packaged Python package,
#34 0.550     create a virtual environment using python3 -m venv path/to/venv.
#34 0.550     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
#34 0.550     sure you have python3-full installed.
#34 0.550     
#34 0.550     If you wish to install a non-Debian packaged Python application,
#34 0.550     it may be easiest to use pipx install xyz, which will manage a
#34 0.550     virtual environment for you. Make sure you have pipx installed.
#34 0.550     
#34 0.550     See /usr/share/doc/python3.11/README.venv for more information.
#34 0.550 
#34 0.550 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
#34 0.550 hint: See PEP 668 for the detailed specification.
```