### PR TITLE
Update default OCSP lifetime

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.2
+current_version = 1.0.3
 commit = False
 tag = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ocsprest"
-version = "1.0.2"
+version = "1.0.3"
 description = ""
 authors = ["Eero af Heurlin <eero.afheurlin@iki.fi>"]
 readme = "README.rst"

--- a/src/ocsprest/__init__.py
+++ b/src/ocsprest/__init__.py
@@ -1,2 +1,2 @@
 """Quick and dirty rest API to call the ocsp signing methods for CFSSL CLI"""
-__version__ = "1.0.2"
+__version__ = "1.0.3"

--- a/src/ocsprest/config.py
+++ b/src/ocsprest/config.py
@@ -46,6 +46,8 @@ class RESTConfig(BaseSettings):
         description="Location to dump the DER CRL to, .PEM version will also be created", default="/ca_public/crl.der"
     )
     crl_lifetime: str = Field(description="Lifetime to pass to CFSSL", default="1800s")
+    # OCSP responder rounds the response nextupdate in funky ways so less than 1h will lead to weird results
+    ocsp_lifetime: str = Field(description="Lifetime to pass to CFSSL", default="1h")
     crl_refresh: int = Field(description="Interval to dump CRL via out background task", default=900)
 
     ci: bool = Field(default=False, alias="CI", description="Are we running in CI")

--- a/src/ocsprest/helpers.py
+++ b/src/ocsprest/helpers.py
@@ -135,7 +135,7 @@ async def refresh_oscp() -> int:
         f"-ca-key {cnf.cakey}",
         f"-responder {cnf.respcrt}",
         f"-responder-key {cnf.respkey}",
-        f"-interval {cnf.crl_lifetime}",
+        f"-interval {cnf.ocsp_lifetime}",
         f"-loglevel {cfssl_loglevel()}",
     ]
     cmd = " ".join(args)

--- a/tests/test_ocsprest.py
+++ b/tests/test_ocsprest.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.0.2"
+    assert __version__ == "1.0.3"
 
 
 def test_healthcheck(client: TestClient) -> None:


### PR DESCRIPTION
Minimum is 1h and I think any amount that does not divide into whole numbers by 1h will lead to tears